### PR TITLE
add support for running on all when when set to *

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ name = "minecraft"
 
 # Lists the hosts on which this stack should run.
 # It should match the hostname of your docker host.
+# Set to * to run on all hosts.
 runs_on = ["mydockerhostname"]
 ```
 

--- a/src/deploy_file.rs
+++ b/src/deploy_file.rs
@@ -62,7 +62,7 @@ pub fn load_stacks(root: &str, files: &[PathBuf]) -> anyhow::Result<Vec<DeployFi
             .with_context(|| format!("failed to parse {path:?} as toml"))?;
         println!("{deploy:#?}");
 
-        if deploy.runs_on.contains(&hostname) {
+        if deploy.runs_on.contains(&hostname) || deploy.runs_on.contains(&"*".to_string()) {
             anyhow::ensure!(
                 !stacks.contains_key(&deploy.name),
                 "multiple stacks have the same name {}",


### PR DESCRIPTION
When creating a VPS, some providers will set the hostnames. While we can easily configure it, adding support for `*` to run on all hosts makes it easy. This allows me to easily spin up VMs and try it out without always having to go and update the `stack-deploy.toml` file.