### PR TITLE
add support for pre_start and post_start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,19 @@ name = "homepage"
 runs_on = ["docker1"]
 # It requires that the traefik stack on docker1 be deployed first
 depends_on = ["traefik"]
+# It has a pre-start script that should be run before the stack is started
+pre_start = ["./pre_start"]
+# It has a post-script that should be run after the stack is started
+post_start = ["./post_start"]
 ```
 
 The stacks are topologically sorted based on their dependencies and then
 started in that order.
 
 It is not possible to depend on stacks that are running on other hosts.
+
+`pre_start` and `post_start` scripts can be run to do any necessary setup such
+as creating network resources.
 
 ## Stopping and removing a Stack
 

--- a/src/deploy_file.rs
+++ b/src/deploy_file.rs
@@ -26,6 +26,14 @@ pub struct StackDeploy {
     #[serde(default)]
     pub secret_env: BTreeMap<String, String>,
 
+    /// List of scripts to run before starting the stack
+    #[serde(default)]
+    pub pre_start: Vec<String>,
+
+    /// List of scripts to run after starting the stack
+    #[serde(default)]
+    pub post_start: Vec<String>,
+
     // TODO: secret_file
     /// List of host names on which to run this service
     pub runs_on: Vec<String>,


### PR DESCRIPTION
Added `pre_start` and `post_start` scripting support in `stack-deploy.toml`. 

This will allow us to run custom scripts and can be useful when setting us networks for reverse proxy that is external.

Example for `pre_start` script for creating a network for traefik.

```bash
#!/bin/sh
NETWORK_NAME="reverse_proxy"

if ! docker network ls --filter name=^${NETWORK_NAME}$ --format "{{.Name}}" | grep -wq ${NETWORK_NAME}; then
  echo "Network '${NETWORK_NAME}' does not exist. Creating it now..."
  docker network create ${NETWORK_NAME}
else
  echo "Network '${NETWORK_NAME}' already exists."
fi
```

I also pass the `secret_env` so this could be used to replace values in config files that is outside of compose.yml.